### PR TITLE
Add limits

### DIFF
--- a/src/pugme.coffee
+++ b/src/pugme.coffee
@@ -5,13 +5,14 @@
 #   None
 #
 # Configuration:
-#   None
+#   HUBOT_PUGBOMB_MAX - The most pugs you can bomb.  Default: -1 (unlimited)
 #
 # Commands:
 #   hubot pug me - Receive a pug
 #   hubot pug bomb N - get N pugs
 
 module.exports = (robot) ->
+  max = (process.env.HUBOT_PUGBOMB_MAX*1) or -1
 
   robot.respond /pug me/i, (msg) ->
     msg.http("http://pugme.herokuapp.com/random")
@@ -20,6 +21,11 @@ module.exports = (robot) ->
 
   robot.respond /pug bomb( (\d+))?/i, (msg) ->
     count = msg.match[2] || 5
+    if max > -1
+      if (count*1) > max
+        msg.send 'You asked for too many pugs.\nYou get NONE!\nNO PUGS FOR YOU!'
+        return
+
     msg.http("http://pugme.herokuapp.com/bomb?count=" + count)
       .get() (err, res, body) ->
         msg.send pug for pug in JSON.parse(body).pugs
@@ -28,4 +34,3 @@ module.exports = (robot) ->
     msg.http("http://pugme.herokuapp.com/count")
       .get() (err, res, body) ->
         msg.send "There are #{JSON.parse(body).pug_count} pugs."
-


### PR DESCRIPTION
After Ryan said "hubot pug bomb 400', none of us can have nice things anymore.  Default behavior is unchanged, but add HUBOT_PUGBOMB_MAX=[number] to keep Ryan from breaking Slack again.
