### PR TITLE
[dev-tumblr-dns-hack] Tumblr #ed URLs broken

### DIFF
--- a/src/pugme.coffee
+++ b/src/pugme.coffee
@@ -16,13 +16,13 @@ module.exports = (robot) ->
   robot.respond /pug me/i, (msg) ->
     msg.http("http://pugme.herokuapp.com/random")
       .get() (err, res, body) ->
-        msg.send JSON.parse(body).pug
+        msg.send "http://" + JSON.parse(body).pug.split(".").slice(1).join(".")
 
   robot.respond /pug bomb( (\d+))?/i, (msg) ->
     count = msg.match[2] || 5
     msg.http("http://pugme.herokuapp.com/bomb?count=" + count)
       .get() (err, res, body) ->
-        msg.send pug for pug in JSON.parse(body).pugs
+        msg.send ("http://" + pug.split(".").slice(1).join(".")) for pug in JSON.parse(body).pugs
 
   robot.respond /how many pugs are there/i, (msg) ->
     msg.http("http://pugme.herokuapp.com/count")


### PR DESCRIPTION
- Strip out the initial number for Tumblr media URLs