### PR TITLE
https instead of http

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hubot-pugme",
   "description": "Pugme is the most important hubot script",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "author": "Josh Nichols <technicalpickles@github.com>",
   "license": "MIT",
   "keywords": "hubot, hubot-scripts, pugs",

--- a/src/pugme.coffee
+++ b/src/pugme.coffee
@@ -16,7 +16,9 @@ module.exports = (robot) ->
   robot.respond /pug me/i, (msg) ->
     msg.http("http://pugme.herokuapp.com/random")
       .get() (err, res, body) ->
-        msg.send JSON.parse(body).pug
+        text = JSON.parse(body).pug
+        text = text.replace "http:", "https:"
+        msg.send text
 
   robot.respond /pug bomb( (\d+))?/i, (msg) ->
     count = msg.match[2] || 5


### PR DESCRIPTION
If you're running your bot in a https environment, this script will get that little green lock a warning symbol - so it's better to just return https results instead.